### PR TITLE
Reconnection and chunk-parsing fixes

### DIFF
--- a/src/remote/RemoteManager.js
+++ b/src/remote/RemoteManager.js
@@ -138,13 +138,6 @@ class RemoteManager extends EventEmitter {
                     if(this.error.code === "ECONNRESET"){
                         this.emit('unpaired');
                     }
-                    else if(this.error.code === "ECONNREFUSED"){
-                        // L'appareil n'est pas encore prêt : on relance
-                        await this.maybeReconnect();
-                    }
-                    else if(this.error.code === "EHOSTDOWN"){
-                        // L'appareil est down, on ne fait rien
-                    }
                     else{
                         // Dans le doute on redémarre
                         await this.maybeReconnect();


### PR DESCRIPTION
- make message reading and decoding more robust to support messages larger than 127 bytes and multiple messages arriving at once
- clear chunks and error on start so that reconnects work properly if those previously had values
- suppress automatic reconnects after calling stop