### PR TITLE
📢 Send Text to Android TV

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ androidRemote.on('ready', async () => {
 
     androidRemote.sendKey(RemoteKeyCode.MUTE, RemoteDirection.SHORT)
 
+    androidRemote.sendText("Hello World!")
+
     androidRemote.sendAppLink("https://www.disneyplus.com");
 });
 
@@ -81,6 +83,11 @@ Emitted when androidtv has a problem : by example when you send a wrong app_link
 
 ### `Command: sendCode(code)`
 - `code` : You need to pass the shown code on the TV when asked
+
+### `Command: sendText(text)`
+- `text` : You need to pass the text to send
+  * This may not work when virtual keyboard is open on TV
+  * To hide virtual keyboard, send `sendKey(RemoteKeyCode.KEYCODE_BACK, RemoteDirection.SHORT)`
 
 ### `Command: sendKey(KeyCode, Direction)`
 - `KeyCode` : Any key of https://developer.android.com/reference/android/view/KeyEvent?hl=fr

--- a/example/example.js
+++ b/example/example.js
@@ -55,6 +55,12 @@ androidRemote.on('ready', async () => {
     await new Promise(resolve => setTimeout(resolve, 100));
     androidRemote.sendKey(RemoteKeyCode.KEYCODE_0, RemoteDirection.END_LONG)
 
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    androidRemote.sendText("Hello");
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    androidRemote.sendText(" World!");
+
     androidRemote.sendKey(RemoteKeyCode.KEYCODE_MUTE, RemoteDirection.SHORT)
     await new Promise(resolve => setTimeout(resolve, 10000));
     androidRemote.sendAppLink("https://www.disneyplus.com");

--- a/example/package.json
+++ b/example/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "androidtv-remote": "^1.0.10"
+    "androidtv-remote": "file:../"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "androidtv-remote",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "AndroidTV Remote",
   "main": "dist/index.js",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,10 @@ export class AndroidRemote extends EventEmitter {
         return this.remoteManager.sendKey(key, direction);
     }
 
+    sendText(text){
+        return this.remoteManager.sendText(text);
+    }
+
     getCertificate(){
         return {
             key:this.cert.key,

--- a/src/remote/RemoteManager.js
+++ b/src/remote/RemoteManager.js
@@ -75,6 +75,7 @@ class RemoteManager extends EventEmitter {
                     }
                     else if(message.remoteImeBatchEdit){
                         console.debug("Receive IME BATCH EDIT" + message.remoteImeBatchEdit);
+                        this.remoteImeBatchEditResponse = JSON.parse(JSON.stringify(message.remoteImeBatchEdit));
                     }
                     else if(message.remoteImeShowRequest){
                         console.debug("Receive IME SHOW REQUEST" + message.remoteImeShowRequest);
@@ -165,6 +166,23 @@ class RemoteManager extends EventEmitter {
         this.client.write(remoteMessageManager.createRemoteKeyInject(
             direction,
             key));
+    }
+
+    sendText(text){
+        let _imeCounter = 0;
+        let _fieldCounter = 0;
+        if (this.remoteImeBatchEditResponse) {
+            if (this.remoteImeBatchEditResponse.imeCounter) {
+                _imeCounter = this.remoteImeBatchEditResponse.imeCounter;
+            }
+            if (this.remoteImeBatchEditResponse.fieldCounter) {
+                _fieldCounter = this.remoteImeBatchEditResponse.fieldCounter;
+            }
+        }
+        this.client.write(remoteMessageManager.createRemoteImeBatchEdit(
+            text,
+            _imeCounter,
+            _fieldCounter));
     }
 
     sendAppLink(app_link){

--- a/src/remote/RemoteMessageManager.js
+++ b/src/remote/RemoteMessageManager.js
@@ -112,6 +112,23 @@ class RemoteMessageManager {
         });
     }
 
+    createRemoteImeBatchEdit(text, imeCounter, fieldCounter) {
+        return this.create({
+            remoteImeBatchEdit: {
+                imeCounter,
+                fieldCounter,
+                editInfo: [{
+                    insert: 0,
+                    textFieldStatus: {
+                        start: text.length - 1,
+                        end: text.length - 1,
+                        value: text 
+                    }
+                }]
+            }
+        });
+    }
+
     parse(buffer){
         return this.RemoteMessage.decodeDelimited(buffer);
     }

--- a/src/remote/remotemessage.proto
+++ b/src/remote/remotemessage.proto
@@ -59,13 +59,20 @@ message RemoteImeShowRequest {
 }
 
 message RemoteEditInfo {
-  int32 insert = 2;
+  int32 insert = 1;
+  RemoteImeObject text_field_status = 2;
+}
+
+message RemoteImeObject {
+  int32 start = 1;
+  int32 end = 2;
+  string value = 3;
 }
 
 message RemoteImeBatchEdit {
   int32 ime_counter = 1;
   int32 field_counter = 2;
-  RemoteEditInfo edit_info = 3;
+  repeated RemoteEditInfo edit_info = 3;
 }
 
 message RemoteAppInfo {


### PR DESCRIPTION
🔹 What’s New?
	•	Added support for sending text from a phone to Android TV.
	•	Works when the virtual keyboard is hidden (currently may not type with it open).
🔹 Fixes & Changes
	•	Fixed missing proto messages and incorrect data formats.
	•	RemoteImeBatchEdit.edit_info → should be an array.
	•	RemoteEditInfo → added missing text_field_status (type: RemoteImeObject).

💡 Need this or other feature for iOS or another TV platforms? Send me a message.

❤️ Consider sponsoring to help me continue with voice and other nice features. Support My Work 🚀